### PR TITLE
feat(app): create quick events from a phrase

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ Apple Calendar-inspired application with day, week and month views, drag and dro
 - **Infinite month scrolling** - Virtualized with the [`ScrollArea`](https://ui.nuxt.com/docs/components/scroll-area) component, streaming events in aligned 6-week chunks while the URL and title follow as you scroll
 - **Drag and drop** - Move events across days, drag the bottom edge to resize, snapped to 15 minutes
 - **Inline event editing** - Double-click or drag the grid to draw an event where you point, across days for an all-day one, then fill it in from a popover anchored to it, the same form an existing event opens into
+- **Quick event** - Type "Movie at 7pm on Friday" into the `+` menu and [gpu-time](https://github.com/arikchakma/gpu-time) reads the time out of it in the browser, the rest becomes the title and the event lands on its day as a draft to check before it saves
 - **Optimistic mutations** - Creations, edits and deletions apply instantly to a client overlay re-applied over every server response, with rollback and a toast on failure
 - **Offline support** - Mutations queue while offline and replay on reconnect thanks to upsert and idempotent server semantics, with an indicator in the header
 - **Payload caching** - Each visible range is a keyed `useFetch` with `getCachedData`, adjacent ranges are warmed in the background so a prev/next click never waits on the network

--- a/app/components/AppSidebar.vue
+++ b/app/components/AppSidebar.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 const { isSearchOpen, isSidebarOpen } = useCalendar()
-const { draft, createAtAnchor } = useEventDraft()
+const { draft } = useEventDraft()
 
 const route = useRoute()
 
@@ -40,29 +40,19 @@ watch([() => route.fullPath, () => !!draft.value, isSearchOpen], () => {
         <span class="text-xl font-bold text-highlighted">Calendar</span>
       </NuxtLink>
 
-      <UTheme :props="{ button: { size: 'sm', class: 'rounded-full!' } }">
-        <div class="ms-auto flex items-center gap-1.5">
-          <UTooltip
-            text="New event"
-            :kbds="['n']"
-          >
-            <UButton
-              icon="i-lucide-plus"
-              aria-label="New event"
-              @click="createAtAnchor()"
-            />
-          </UTooltip>
+      <div class="ms-auto flex items-center gap-1.5">
+        <NewEventMenu />
 
-          <UButton
-            icon="i-lucide-x"
-            color="neutral"
-            variant="soft"
-            aria-label="Close menu"
-            class="lg:hidden rounded-full"
-            @click="close"
-          />
-        </div>
-      </UTheme>
+        <UButton
+          icon="i-lucide-x"
+          color="neutral"
+          variant="soft"
+          size="sm"
+          aria-label="Close menu"
+          class="lg:hidden rounded-full"
+          @click="close"
+        />
+      </div>
     </template>
 
     <UButton

--- a/app/components/NewEventMenu.vue
+++ b/app/components/NewEventMenu.vue
@@ -1,0 +1,108 @@
+<script setup lang="ts">
+const { createAtAnchor, createFromQuick } = useEventDraft()
+
+const open = ref(false)
+const text = ref('')
+const loading = ref(false)
+
+// A ghost's form takes the focus as it opens, and the focus this menu hands
+// back to its button as it closes would take it straight out again: a form
+// losing the focus is dismissed, and dismissing a draft's form saves it
+let handedOff = false
+
+const content = {
+  side: 'bottom',
+  align: 'start',
+  alignOffset: -14,
+  onCloseAutoFocus: (event: Event) => {
+    if (handedOff) {
+      event.preventDefault()
+      handedOff = false
+    }
+  }
+} as const
+
+function handOff(create: () => Promise<void>) {
+  handedOff = true
+  open.value = false
+
+  return create()
+}
+
+// The model reads the phrase in the browser, and is a download the first time
+// it does: the input holds on with a spinner until it has, and only then
+// steps aside for the ghost
+async function onSubmit() {
+  const phrase = text.value.trim()
+  if (!phrase || loading.value) {
+    return
+  }
+
+  loading.value = true
+
+  try {
+    const quick = await parseQuickEvent(phrase)
+
+    text.value = ''
+
+    await handOff(() => createFromQuick(quick, phrase))
+  } finally {
+    loading.value = false
+  }
+}
+</script>
+
+<template>
+  <UPopover
+    v-model:open="open"
+    :content="content"
+    :ui="{ content: 'p-2 w-72 max-w-[calc(100vw-1rem)]' }"
+  >
+    <UTooltip text="New event">
+      <UButton
+        icon="i-lucide-plus"
+        size="sm"
+        aria-label="New event"
+        class="rounded-full"
+      />
+    </UTooltip>
+
+    <template #content>
+      <UButton
+        icon="i-lucide-calendar-plus"
+        label="New event"
+        color="neutral"
+        variant="ghost"
+        block
+        class="justify-start"
+        @click="handOff(createAtAnchor)"
+      >
+        <template #trailing>
+          <UKbd
+            value="n"
+            variant="soft"
+            class="ms-auto"
+          />
+        </template>
+      </UButton>
+
+      <USeparator class="my-2" />
+
+      <form @submit.prevent="onSubmit">
+        <UFormField
+          label="Create quick event"
+          class="px-1 pb-1"
+        >
+          <UInput
+            v-model="text"
+            placeholder="Movie at 7pm on Friday"
+            :loading="loading"
+            :maxlength="100"
+            autofocus
+            class="w-full"
+          />
+        </UFormField>
+      </form>
+    </template>
+  </UPopover>
+</template>

--- a/app/components/calendar/EventDraft.vue
+++ b/app/components/calendar/EventDraft.vue
@@ -83,17 +83,25 @@ watch(pendingScroll, reveal)
     @update:open="onUpdateOpen"
   >
     <template #anchor>
+      <!-- Dressed as the event it is about to be, with its form open: the
+        chip wears the held shade a selected chip does, and only an all-day
+        one the tinted pill, so nothing changes about it when Enter saves it -->
       <div
         ref="el"
         v-bind="$attrs"
         data-draft
+        :data-active="variant === 'chip' || undefined"
         aria-hidden="true"
         class="select-none transition-colors"
         :class="[
-          eventBlockClasses[color],
           variant === 'block'
-            ? 'absolute z-20 flex flex-col items-start overflow-hidden rounded-xs px-3 py-1 text-xs text-start'
-            : 'flex items-center gap-1.5 min-w-0 rounded-full px-1.5 py-0.5 text-xs',
+            ? [eventBlockClasses[color], 'absolute z-20 flex flex-col items-start overflow-hidden rounded-xs px-3 py-1 text-xs text-start']
+            : [
+              'flex items-center gap-1.5 min-w-0 rounded-full px-1.5 py-0.5 text-xs',
+              draft!.allDay
+                ? eventBlockClasses[color]
+                : ['text-default data-active:bg-(--control-bg)', eventChipCompactClasses[color]]
+            ],
           continuesBefore && 'rounded-s-none',
           continuesAfter && 'rounded-e-none'
         ]"
@@ -104,6 +112,21 @@ watch(pendingScroll, reveal)
           class="absolute inset-s-1 inset-y-1 w-1 rounded-full"
           :class="calendarDotClasses[color]"
         />
+        <span
+          v-else-if="draft!.allDay"
+          :class="calendarDotClasses[color]"
+          class="rounded-full flex items-center justify-center p-0.5 -mx-0.75"
+        >
+          <UIcon
+            name="i-lucide-calendar"
+            class="size-2.5 shrink-0 text-inverted"
+          />
+        </span>
+        <span
+          v-else
+          class="max-lg:hidden size-2 shrink-0 rounded-full"
+          :class="calendarDotClasses[color]"
+        />
 
         <span
           class="font-medium truncate"
@@ -112,8 +135,8 @@ watch(pendingScroll, reveal)
 
         <span
           v-if="times"
-          class="truncate opacity-80 tabular-nums"
-          :class="variant === 'block' ? 'w-full' : 'ms-auto shrink-0 text-[11px]'"
+          class="truncate tabular-nums"
+          :class="variant === 'block' ? 'w-full opacity-80' : 'ms-auto shrink-0 text-muted text-[11px]'"
         >{{ variant === 'block' ? times : formatTime(draft!.start) }}</span>
       </div>
     </template>
@@ -123,6 +146,7 @@ watch(pendingScroll, reveal)
         v-if="draft"
         :draft="draft"
         @update="updateDraft"
+        @submit="commitDraft(true)"
         @escape="discardDraft(true)"
       />
     </template>

--- a/app/components/calendar/EventForm.vue
+++ b/app/components/calendar/EventForm.vue
@@ -19,7 +19,28 @@ const emit = defineEmits<{
   save: [event: CalendarEvent]
   remove: [id: string]
   escape: []
+  submit: []
 }>()
+
+const form = useTemplateRef('form')
+
+// Enter is Escape's counterpart, the way out that keeps what was written, and
+// caught on the way down for the same reason: the segments swallow it. It goes
+// through the form rather than the browser's implicit submission, which only
+// the title input would trigger. The fields with a meaning of their own for it
+// keep it, the select opening its list, the checkbox declining to toggle, the
+// notes taking a new line
+function onEnter(event: KeyboardEvent) {
+  const target = event.target as HTMLElement
+
+  if (target.tagName === 'TEXTAREA' || target.closest('[role="combobox"],[role="checkbox"]')) {
+    return
+  }
+
+  event.preventDefault()
+  event.stopPropagation()
+  form.value?.submit()
+}
 
 const { calendars } = useCalendarEvents()
 
@@ -190,10 +211,13 @@ watch(
     down instead, before a segment can take it. The pickers hang their content
     off the body, so their own Escape never comes through here -->
   <UForm
+    ref="form"
     :schema="formSchema"
     :state="state"
     class="flex flex-col gap-2"
     @keydown.escape.capture.stop="emit('escape')"
+    @keydown.enter.capture="onEnter"
+    @submit="emit('submit')"
   >
     <div class="flex items-center px-3 py-2 rounded-md bg-(--control-bg)">
       <UFormField

--- a/app/components/calendar/EventPopover.vue
+++ b/app/components/calendar/EventPopover.vue
@@ -116,6 +116,7 @@ const items = computed<ContextMenuItem[]>(() => [{
               :event="event"
               @save="updateEvent"
               @remove="onRemove"
+              @submit="closeEvent(event.id)"
               @escape="closeEvent(event.id)"
             />
           </template>

--- a/app/composables/useEventDraft.ts
+++ b/app/composables/useEventDraft.ts
@@ -74,12 +74,12 @@ const _useEventDraft = () => {
     return visible?.id ?? calendars.value[0]?.id ?? 'work'
   }
 
-  function createDraft(input: { start: Date, end: Date, allDay?: boolean, scroll?: boolean }) {
+  function createDraft(input: { start: Date, end: Date, allDay?: boolean, title?: string, scroll?: boolean }) {
     draft.value = {
       start: input.start,
       end: input.end,
       allDay: input.allDay ?? false,
-      title: '',
+      title: input.title ?? '',
       calendarId: defaultCalendarId(),
       description: ''
     }
@@ -118,8 +118,9 @@ const _useEventDraft = () => {
   }
 
   // Everything the event needs is already on the draft, there is no form to
-  // hand it over: what the ghost is showing is what gets saved
-  function commitDraft() {
+  // hand it over: what the ghost is showing is what gets saved. Enter in the
+  // form commits it and hands the focus back the way Escape does
+  function commitDraft(refocus = false) {
     if (!draft.value) {
       return
     }
@@ -134,12 +135,12 @@ const _useEventDraft = () => {
       allDay: draft.value.allDay || undefined
     })
 
-    discardDraft()
+    discardDraft(refocus)
   }
 
   // The `+` button, `n` and the command palette. They draw on the date the
   // route is on rather than navigating somewhere else
-  async function createAtAnchor() {
+  async function createAtAnchor(title = '') {
     // Nowhere to draw here, so land on a grid first
     if (!hosts.value) {
       await navigateTo(pathFor(date.value))
@@ -149,7 +150,24 @@ const _useEventDraft = () => {
     const hour = Math.min(23, new Date().getHours() + 1)
     const start = addMinutes(startOfDay(toDate(date.value)), hour * 60)
 
-    createDraft({ start, end: addMinutes(start, 60), scroll: true })
+    createDraft({ start, end: addMinutes(start, 60), title, scroll: true })
+  }
+
+  // The quick event input. What the phrase says is drawn as a draft rather
+  // than saved outright, so what was read into it is on screen to be put
+  // right before it is. Always lands on its day: the month view scrolls to a
+  // route change, and the small-screen week window slides to it, where a day
+  // merely inside the fetched range could still be off screen with no ghost
+  // mounted to scroll to
+  async function createFromQuick(quick: QuickEvent | null, text: string) {
+    // No time in it, so it goes where the `+` button would put it
+    if (!quick) {
+      return createAtAnchor(text)
+    }
+
+    await navigateTo(pathFor(toCalendarDate(quick.start)))
+
+    createDraft({ ...quick, scroll: true })
   }
 
   let gesture: Gesture | null = null
@@ -347,6 +365,7 @@ const _useEventDraft = () => {
     discardDraft,
     commitDraft,
     createAtAnchor,
+    createFromQuick,
     onGridPointerdown,
     onGridDblclick,
     registerHost,

--- a/app/utils/quickEvent.ts
+++ b/app/utils/quickEvent.ts
@@ -1,0 +1,117 @@
+import { getLocalTimeZone } from '@internationalized/date'
+import { addDays, addMinutes } from 'date-fns'
+
+export interface QuickEvent {
+  title: string
+  start: Date
+  end: Date
+  allDay: boolean
+}
+
+type Parsed = Awaited<ReturnType<typeof import('gpu-time')['parse']>>
+
+// Words a title spends leading into its time, "Movie at 7pm", and would be
+// left holding once the time is taken out
+const CONNECTORS = new Set(['at', 'on', 'in', 'from', 'for', 'until', 'till', 'to', 'by', '@', '-', 'the', 'this', 'next', 'every', 'and'])
+
+// What a phrase resolves to, so two phrases can be told to mean the same time
+function signature(result: Parsed): string {
+  return JSON.stringify([result.occurrences, result.rrules])
+}
+
+function silent(result: Parsed): boolean {
+  return !result.occurrences.length && !result.rrules.length
+}
+
+// Reads "Movie at 7pm on Friday" into a title and a time. `gpu-time` says
+// when the phrase happens but not which words said so, and the title is the
+// rest of the phrase: the fewest words that still resolve to the same time
+// are the time, provided what is left around them says no time of its own,
+// or "tomorrow at 9" would be titled "tomorrow" on the strength of "9" alone
+// resolving the same way until 9am has passed. Trimmed from the front and
+// then from the back, a location after the time survives, "Dinner at 8 at
+// Nobu". Returns `null` for a phrase with no time in it, the caller picks one
+export async function parseQuickEvent(text: string): Promise<QuickEvent | null> {
+  const phrase = text.trim()
+  if (!phrase) {
+    return null
+  }
+
+  try {
+    const { parse, parseMany } = await import('gpu-time')
+
+    const context = {
+      reference: new Date().toISOString(),
+      timeZone: getLocalTimeZone(),
+      weekStart: 'MO' as const,
+      limit: 1
+    }
+
+    const base = await parse(phrase, context)
+    const occurrence = base.occurrences[0]
+    if (!occurrence) {
+      return null
+    }
+
+    const expected = signature(base)
+    const words = phrase.split(/\s+/)
+
+    // The most words the front can spare: every candidate goes through the
+    // model in a single batch and the longest lead-in that holds is taken
+    const heads = words.slice(1).flatMap((_, index) => [
+      words.slice(0, index + 1).join(' '),
+      words.slice(index + 1).join(' ')
+    ])
+    const headResults = await parseMany(heads, context)
+
+    let leading = 0
+    for (let count = words.length - 1; count >= 1; count--) {
+      if (silent(headResults[(count - 1) * 2]!) && signature(headResults[(count - 1) * 2 + 1]!) === expected) {
+        leading = count
+        break
+      }
+    }
+
+    const prefix = words.slice(0, leading)
+    const core = words.slice(leading)
+
+    // Then the back, with the lead-in kept in the remainder being tested so
+    // the two halves are known to say nothing together either
+    const tails = core.slice(1).flatMap((_, index) => [
+      [...prefix, ...core.slice(core.length - index - 1)].join(' '),
+      core.slice(0, core.length - index - 1).join(' ')
+    ])
+    const tailResults = tails.length ? await parseMany(tails, context) : []
+
+    let trailing = 0
+    for (let count = core.length - 1; count >= 1; count--) {
+      if (silent(tailResults[(count - 1) * 2]!) && signature(tailResults[(count - 1) * 2 + 1]!) === expected) {
+        trailing = count
+        break
+      }
+    }
+
+    const suffix = core.slice(core.length - trailing)
+
+    while (prefix.length && CONNECTORS.has(prefix.at(-1)!.toLowerCase())) {
+      prefix.pop()
+    }
+
+    const start = new Date(occurrence.start)
+    // A time with no end runs the hour a drawn draft does, a day with no
+    // time is the whole of it
+    const end = occurrence.end
+      ? new Date(occurrence.end)
+      : occurrence.allDay ? addDays(start, 1) : addMinutes(start, 60)
+
+    return {
+      title: [...prefix, ...suffix].join(' '),
+      start,
+      end,
+      allDay: occurrence.allDay
+    }
+  } catch {
+    // The model could not load or run here, the phrase still makes an event
+    return null
+  }
+}

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "@vueuse/core": "^14.4.0",
     "@vueuse/nuxt": "^14.4.0",
     "date-fns": "^4.4.0",
+    "gpu-time": "^0.1.0",
     "nuxt": "^4.5.2",
     "tailwindcss": "^4.3.3",
     "zod": "^4.5.4"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -130,6 +130,9 @@ importers:
       date-fns:
         specifier: ^4.4.0
         version: 4.4.0
+      gpu-time:
+        specifier: ^0.1.0
+        version: 0.1.0
       nuxt:
         specifier: ^4.5.2
         version: 4.5.2(@babel/plugin-syntax-jsx@7.29.7(@babel/core@7.29.7(supports-color@10.2.2)))(@babel/plugin-syntax-typescript@7.29.7(@babel/core@7.29.7(supports-color@10.2.2)))(@oxc-project/types@0.143.0)(@vue/compiler-sfc@3.5.41)(cac@7.0.0)(db0@0.3.4)(esbuild@0.28.2)(eslint@10.10.0(jiti@2.7.0)(supports-color@10.2.2))(ioredis@5.11.1(supports-color@10.2.2))(lightningcss@1.33.0)(magicast@0.5.4)(optionator@0.9.4)(rolldown@1.2.3)(rollup-plugin-visualizer@7.0.1(rolldown@1.2.3)(rollup@4.62.4))(rollup@4.62.4)(srvx@0.11.22)(supports-color@10.2.2)(terser@5.49.2)(typescript@6.0.3)(vite@8.2.1(esbuild@0.28.2)(jiti@2.7.0)(terser@5.49.2)(yaml@2.9.0))(vue-tsc@3.3.11(typescript@6.0.3))(yaml@2.9.0)
@@ -3154,6 +3157,9 @@ packages:
   globby@16.2.3:
     resolution: {integrity: sha512-VZX7TV7jmd/pn71vdnLKtgwy1IWqc3KjI9x1/UtPkwoKk5fKrNLY30ltDe3cAM5xruIN7YuuaulFt133jRrKZg==}
     engines: {node: '>=20'}
+
+  gpu-time@0.1.0:
+    resolution: {integrity: sha512-OyZZyDq5vZu1o7ZTMiyTJS0wT9n2544Jl8lT+ykMHxyVV9z195cb9seyU8jXSmWIi7yUggPVdKkSEwc2wo33fg==}
 
   graceful-fs@4.2.11:
     resolution: {integrity: sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==}
@@ -8517,6 +8523,8 @@ snapshots:
       is-path-inside: 4.0.0
       slash: 5.1.0
       unicorn-magic: 0.4.0
+
+  gpu-time@0.1.0: {}
 
   graceful-fs@4.2.11: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -4,3 +4,6 @@ allowBuilds:
   esbuild: false
   unrs-resolver: false
   vue-demi: false
+
+minimumReleaseAgeExclude:
+  - gpu-time@0.1.0


### PR DESCRIPTION
The \`+\` button now opens a menu with a "New event" item and a "Create quick event" input, the way Apple Calendar does it. Type "Movie at 7pm on Friday" and the event lands on its day as a draft with the form open, so what was read into it can be checked before it saves.

- [gpu-time](https://github.com/arikchakma/gpu-time) reads the time out of the phrase in the browser, lazy-loaded in its own chunk. It returns occurrences but not which words said so, so the title is worked out by finding the fewest words that still resolve to the same time while the rest resolves to nothing. "Dinner at 8 at Nobu" gives "Dinner at Nobu".
- A phrase with no time in it goes where the \`+\` button would put it, with the phrase as title. Recurring phrases keep their first occurrence, the app has no recurrence.
- Enter in the event form now commits it and closes the popover, the counterpart of Escape, for drafts and existing events alike. The calendar select, the checkbox and the notes keep the key for themselves.
- The ghost chip in the month view now wears what a selected chip does, so nothing changes about it when Enter saves it.

\`pnpm-workspace.yaml\` gets a \`minimumReleaseAgeExclude\` for \`gpu-time@0.1.0\` since the package is only days old.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Quick Event creation from natural-language phrases, such as “Movie at 7pm on Friday.”
  * Parsed events appear on the appropriate date as drafts for confirmation before saving.
  * Added a dedicated New Event menu for standard and Quick Event creation.

* **Bug Fixes**
  * Pressing Enter now submits event forms where appropriate.
  * Event popovers close after successfully submitting an event.
  * Improved visual styling and readability for timed and all-day event drafts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->